### PR TITLE
Correct omission for RPC update

### DIFF
--- a/_plinode_restore.sh
+++ b/_plinode_restore.sh
@@ -213,7 +213,7 @@ export EI_IC_SECRET=${EXT_SECRET}
 export EI_CI_ACCESSKEY=${EXT_OUTGOINGTOKEN}
 export EI_CI_SECRET=${EXT_OUTGOINGSECRET}
 echo *** Starting EXTERNAL INITIATOR ***
-external-initiator "{\"name\":\"$PLI_E_INIT_NAME\",\"type\":\"xinfin\",\"url\":\"https://plirpc.blocksscan.io\"}" --chainlinkurl "http://localhost:6688/"
+external-initiator "{\"name\":\"$PLI_E_INIT_NAME\",\"type\":\"xinfin\",\"url\":\"https://plixdcrpc.icotokens.net\"}" --chainlinkurl "http://localhost:6688/"
 EOF
     #sleep 1s
     #cat $BASH_FILE3


### PR DESCRIPTION
Omitted the icotoken RPC update to the restore script external-initiator rebuild function.